### PR TITLE
add support for renderOrder to CSS2DRenderer

### DIFF
--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -177,6 +177,12 @@
 
 				const sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
 
+					if ( a.renderOrder !== b.renderOrder ) {
+
+						return b.renderOrder - a.renderOrder;
+
+					}
+
 					const distanceA = cache.objects.get( a ).distanceToCameraSquared;
 					const distanceB = cache.objects.get( b ).distanceToCameraSquared;
 					return distanceA - distanceB;

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -189,6 +189,12 @@ class CSS2DRenderer {
 
 			const sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
 
+				if ( a.renderOrder !== b.renderOrder ) {
+
+					return b.renderOrder - a.renderOrder;
+
+				}
+
 				const distanceA = cache.objects.get( a ).distanceToCameraSquared;
 				const distanceB = cache.objects.get( b ).distanceToCameraSquared;
 


### PR DESCRIPTION
`Object3D` has a concept of `renderOrder` which is useful for resolving the order in which things are rendered. `CSSObject2D` has this property but it (somewhat counterintuitively) does nothing.

This change makes it so that objects in the "CSS scene" are first sorted by `renderOrder`. Where `renderOrder` is the same, objects are then sorted by distance to camera.